### PR TITLE
Explicitly use Python2, not just the default Python.

### DIFF
--- a/bruteforcemindist.py
+++ b/bruteforcemindist.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """Brute force calculation of the minimum distance to assume being attacked using only the number of peers and the HTL.
 

--- a/testfixpitchblack.py
+++ b/testfixpitchblack.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """Testing the fix to the pitch black attack following Oskar Sandberg's fix.
 


### PR DESCRIPTION
On a linux distribution that uses Python3 by default running the previous files will yield Syntax Errors in the print statements. Therefore the files should be explicitly run by Python2, not just any Python. This fixes that.